### PR TITLE
Fix: dedup repeated scheduled runs to get latest completed and success states

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0/3 * * *'
   push:
-    branches: [ main, feat/* ]
+    branches:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /tmp
+/github-api

--- a/src/workflows/summary.rs
+++ b/src/workflows/summary.rs
@@ -71,13 +71,21 @@ impl Summary {
         let created_at = run.created_at;
         let updated_at = run.updated_at;
 
+        // only keep the first run name because repeated run names exist for the
+        // same sha due to scheduling
+        let unique_name = {
+            let mut v = wf.to_vec();
+            v.sort_by_key(|w| w.run.name.as_str());
+            v.dedup_by_key(|w| w.run.name.as_str());
+            v
+        };
         summary.last = Some(LastWorkflow {
             created_at,
             updated_at,
             duration_sec: duration_sec(created_at, updated_at),
             // must check all latset data
-            completed: wf.iter().all(|w| w.run.status == "completed"),
-            success: wf
+            completed: unique_name.iter().all(|w| w.run.status == "completed"),
+            success: unique_name
                 .iter()
                 .all(|w| w.run.conclusion.as_deref() == Some("success")),
             head_branch: run.head_branch.clone(),


### PR DESCRIPTION
* close https://github.com/os-checker/os-checker.github.io/issues/158

![截图_20250406230701](https://github.com/user-attachments/assets/cb2e33e2-90f7-43c4-90e7-cd09145e7826)
